### PR TITLE
Revert "dependabot test"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-
-updates:
-  # Maintain dependencies for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "monthly"


### PR DESCRIPTION
Reverts miraisolutions/ShinyCICD#11

Saw too late that GitHub assumed I wanted to merge this into the original repo rather than the fork...