### PR TITLE
Revert "Bump actions/checkout from 3 to 4"

### DIFF
--- a/.github/workflows/ci-cd-renv.yml
+++ b/.github/workflows/ci-cd-renv.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Setup R
         uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Setup R
         uses: r-lib/actions/setup-r@v2


### PR DESCRIPTION
Reverts miraisolutions/ShinyCICD#18, which was auto-merged via `@dependabot merge` and this caused the workflows run on the merge commit to have`github.actor == "dependabot[bot]"`, which **does have access to secrets**, thus braking the deployments to shinyapps.io as unauthorized
- Deployment error example at https://github.com/miraisolutions/ShinyCICD/actions/runs/7640386058/job/20817426348#step:6:1
  <details>

  ```
      SHINYAPPS_ACCOUNT: 
      SHINYAPPS_TOKEN: 
      SHINYAPPS_SECRET: 
  [...]
  Error in `GET()`:
  ! <https://api.shinyapps.io/v1/users/current/> failed with HTTP status
    401
  Unauthorized
  ```

  </details>

See https://github.com/dependabot/dependabot-core/issues/3253 and in particular
https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544

> ### Why does `@dependabot merge` fail on a `push` event?
>
> The `github.actor == "dependabot[bot]"` since you have asked Dependabot to do the merge (vs a human actor).
>
> We don't recommend commenting `@dependabot merge` to automerge a PR.
 

There is a clear message about **not using `@dependabot merge`**, which we should adhere to.