### PR TITLE
Update/fix for the actions status badges

### DIFF
--- a/.github/workflows/ci-cd-renv.yml
+++ b/.github/workflows/ci-cd-renv.yml
@@ -1,8 +1,9 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 
-# Name of the workflow => usethis::use_github_actions_badge("CI-CD-renv")
+# Name of the workflow
 name: CI-CD-renv
+# Create status badge with usethis::use_github_actions_badge("ci-cd-renv.yml")
 
 on:
   # Triggered on push and pull request events

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,8 +1,9 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 
-# Name of the workflow => usethis::use_github_actions_badge("CI-CD")
+# Name of the workflow
 name: CI-CD
+# Create status badge with usethis::use_github_actions_badge("ci-cd.yml")
 
 on:
   # Triggered on push and pull request events

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 # ShinyCICD
 
 <!-- badges: start -->
-[![CI-CD](https://github.com/miraisolutions/ShinyCICD/workflows/CI-CD/badge.svg)](https://github.com/miraisolutions/ShinyCICD/actions/workflows/ci-cd.yml)
-[![CI-CD-renv](https://github.com/miraisolutions/ShinyCICD/workflows/CI-CD-renv/badge.svg)](https://github.com/miraisolutions/ShinyCICD/actions/workflows/ci-cd-renv.yml)
+[![ci-cd](https://github.com/miraisolutions/ShinyCICD/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/miraisolutions/ShinyCICD/actions/workflows/ci-cd.yml)
+[![ci-cd-renv](https://github.com/miraisolutions/ShinyCICD/actions/workflows/ci-cd-renv.yml/badge.svg)](https://github.com/miraisolutions/ShinyCICD/actions/workflows/ci-cd-renv.yml)
 <!-- badges: end -->
 
 The goal of ShinyCICD is to provide an example of a packaged Shiny app,


### PR DESCRIPTION
- Via `usethis::use_github_actions_badge("ci-cd.yml")`, updated in usethis 2.1.6 (see https://usethis.r-lib.org/news/index.html#usethis-216) to use the same approach and URLs GitHub itself would in 'Create status badge'.
- The existing badge seems broken for `CI-CD`, which is shown as failing, signalling that old URL is not correct.
  - old: [![CI-CD](https://github.com/miraisolutions/ShinyCICD/workflows/CI-CD/badge.svg)](https://github.com/miraisolutions/ShinyCICD/actions/workflows/ci-cd.yml), screenshot:
    ![image](https://github.com/miraisolutions/ShinyCICD/assets/13663564/27ed9695-38ce-4f7b-a90d-1dd3720ea0ae)
  - new: [![ci-cd](https://github.com/miraisolutions/ShinyCICD/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/miraisolutions/ShinyCICD/actions/workflows/ci-cd.yml), screenshot:
    ![image](https://github.com/miraisolutions/ShinyCICD/assets/13663564/4e787e6c-a5a2-4d20-94b0-5872969500e4)

