### PR TITLE
Make sure pak includes "LinkingTo" dependencies to avoid rsconnect errors

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -38,6 +38,9 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       # Preserve package sources for informative references in case of errors
       R_KEEP_PKG_SOURCE: yes
+      # rsconnect needs transitive LinkingTo-only dependencies to be installed
+      # (see https://github.com/r-lib/pak/issues/485)
+      PKG_INCLUDE_LINKINGTO: true
 
     steps:
 


### PR DESCRIPTION
In particular, rsconnect deployments would need all transitive LinkingTo-only dependencies to be installed, but those are by default not installed by pak, see https://github.com/r-lib/pak/issues/485.

A concrete instance of this was detected and fixed in miraisolutions/rTRhexNG#5